### PR TITLE
Create API endpoint that obtains and returns user's saved lists

### DIFF
--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -30,7 +30,7 @@ public class GetUserListsServlet extends HttpServlet {
   public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson g = new Gson();
     String userIdString = request.getParameter("userId");
-    if (userIdString == null) {
+    if (userIdString == null || userIdString == "") {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");
       return;
     }

--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -33,13 +33,13 @@ public class GetUserListsServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson g = new Gson();
-    String reqString = LibraryFunctions.getRequestBody(request);
+    String reqString = ServletUtil.getRequestBody(request);
     RequestBody requestBody = requestValidator(reqString);
     if (requestBody == null) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");
       return;
     }
-    List<List<String>> userLists = suf.getUserLists(requestBody.userId);
+    List<List<String>> userLists = LibraryFunctions.getUserLists(requestBody.userId);
     if (userLists == null) {
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
         "An error occured while retriving data from the database.");

--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -1,0 +1,75 @@
+package com.google.servlets;
+
+import com.google.gson.Gson; 
+import java.lang.StringBuilder;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import javax.servlet.annotation.WebServlet;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@WebServlet("/api/v1/get-user-lists")
+public class GetUserListsServlet extends HttpServlet {
+  private class RequestBody {
+    int userId;
+  }
+
+  private class ResponseBody {
+    List<List<String>> userLists;
+
+    public ResponseBody(List<List<String>> userLists) {
+      this.userLists = userLists;
+    }
+  }
+
+  /*
+   * This handles a POST request to "/get-user-lists". The user's saved lists 
+   * are returned. 
+   */
+  @Override
+  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    Gson g = new Gson();
+    SpannerUtilFunctions suf = new SpannerUtilFunctions();
+    RequestBody requestBody = getRequestBody(request);
+    if (requestBody == null) {
+      response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");
+      return;
+    }
+    List<List<String>> userLists = suf.getUserLists(userId);
+    if (userLists == null) {
+      response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
+        "An error occured while retriving data from the database.");
+      return;
+    }
+
+    ResponseBody responseBody = new ResponseBody(ResponseStatus.SUCCESS, userLists);
+    response.setContentType("application/json;");
+    response.setStatus(HttpServletRequest.SC_OK);
+    response.getWriter().println(g.toJson(responseBody));
+  }
+
+  private RequestBody getRequestBody(HttpServletRequest request) {
+    Gson g = new Gson();
+    StringBuilder sb = new StringBuilder();
+    String reqString = "";
+    String line;
+    try {
+      BufferedReader br = request.getReader();
+      while ((line = br.readLine()) != null) {
+        sb.append(line);
+      }
+    } catch (IOException e) {
+      return null;
+    }
+    reqString = sb.toString();
+    RequestBody requestBody = g.fromJson(reqString, RequestBody.class);
+    if (requestBody == null || requestBody.userId == 0) {
+      return null;
+    }
+    return requestBody;
+  }
+}

--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -33,8 +33,7 @@ public class GetUserListsServlet extends HttpServlet {
   @Override
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson g = new Gson();
-    SpannerUtilFunctions suf = new SpannerUtilFunctions();
-    String reqString = ServerUtil.getRequestBody(request);
+    String reqString = LibraryFunctions.getRequestBody(request);
     RequestBody requestBody = requestValidator(reqString);
     if (requestBody == null) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");

--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -34,38 +34,27 @@ public class GetUserListsServlet extends HttpServlet {
   public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson g = new Gson();
     SpannerUtilFunctions suf = new SpannerUtilFunctions();
-    RequestBody requestBody = getRequestBody(request);
+    String reqString = ServerUtil.getRequestBody(request);
+    RequestBody requestBody = requestValidator(reqString);
     if (requestBody == null) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");
       return;
     }
-    List<List<String>> userLists = suf.getUserLists(userId);
+    List<List<String>> userLists = suf.getUserLists(requestBody.userId);
     if (userLists == null) {
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
         "An error occured while retriving data from the database.");
       return;
     }
 
-    ResponseBody responseBody = new ResponseBody(ResponseStatus.SUCCESS, userLists);
+    ResponseBody responseBody = new ResponseBody(userLists);
     response.setContentType("application/json;");
-    response.setStatus(HttpServletRequest.SC_OK);
+    response.setStatus(HttpServletResponse.SC_OK);
     response.getWriter().println(g.toJson(responseBody));
   }
 
-  private RequestBody getRequestBody(HttpServletRequest request) {
+  private RequestBody requestValidator(String reqString) {
     Gson g = new Gson();
-    StringBuilder sb = new StringBuilder();
-    String reqString = "";
-    String line;
-    try {
-      BufferedReader br = request.getReader();
-      while ((line = br.readLine()) != null) {
-        sb.append(line);
-      }
-    } catch (IOException e) {
-      return null;
-    }
-    reqString = sb.toString();
     RequestBody requestBody = g.fromJson(reqString, RequestBody.class);
     if (requestBody == null || requestBody.userId == 0) {
       return null;

--- a/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetUserListsServlet.java
@@ -14,32 +14,28 @@ import javax.servlet.http.HttpServletResponse;
 
 @WebServlet("/api/v1/get-user-lists")
 public class GetUserListsServlet extends HttpServlet {
-  private class RequestBody {
-    int userId;
-  }
-
   private class ResponseBody {
-    List<List<String>> userLists;
+    List<UserList> userLists;
 
-    public ResponseBody(List<List<String>> userLists) {
+    public ResponseBody(List<UserList> userLists) {
       this.userLists = userLists;
     }
   }
 
   /*
-   * This handles a POST request to "/get-user-lists". The user's saved lists 
+   * This handles a GET request to "/get-user-lists". The user's saved lists 
    * are returned. 
    */
   @Override
-  public void doPost(HttpServletRequest request, HttpServletResponse response) throws IOException {
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
     Gson g = new Gson();
-    String reqString = ServletUtil.getRequestBody(request);
-    RequestBody requestBody = requestValidator(reqString);
-    if (requestBody == null) {
+    String userIdString = request.getParameter("userId");
+    if (userIdString == null) {
       response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid request syntax.");
       return;
     }
-    List<List<String>> userLists = LibraryFunctions.getUserLists(requestBody.userId);
+    long userId = Long.parseLong(userIdString);
+    List<UserList> userLists = LibraryFunctions.getUserLists(userId);
     if (userLists == null) {
       response.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR,
         "An error occured while retriving data from the database.");
@@ -50,14 +46,5 @@ public class GetUserListsServlet extends HttpServlet {
     response.setContentType("application/json;");
     response.setStatus(HttpServletResponse.SC_OK);
     response.getWriter().println(g.toJson(responseBody));
-  }
-
-  private RequestBody requestValidator(String reqString) {
-    Gson g = new Gson();
-    RequestBody requestBody = g.fromJson(reqString, RequestBody.class);
-    if (requestBody == null || requestBody.userId == 0) {
-      return null;
-    }
-    return requestBody;
   }
 }

--- a/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
+++ b/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
@@ -1,0 +1,51 @@
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.BufferedReader;
+import java.io.StringWriter;
+import java.io.StringReader;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import junit.framework.TestCase;
+import org.mockito.Mockito;
+
+public class GetUserListsServletTest extends TestCase {
+  public void testDoPostSucceed() throws ServletException, IOException {
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    StringWriter writer = new StringWriter();
+    StringReader reader = new StringReader(
+        "{\"userId\": 1}");
+    CreateOrUpdateUserlistServlet servlet = new GetUserListsServlet();
+
+    Mockito.when(req.getMethod()).thenReturn("POST");
+    Mockito.when(req.getReader()).thenReturn(new BufferedReader(reader));
+    Mockito.when(res.getWriter()).thenReturn(new PrintWriter(writer));
+
+    servlet.doPost(req, res);
+    Mockito.verify(res).setStatus(HttpServletResponse.SC_OK);
+    String result = writer.toString();
+    assertTrue("should be valid json format", 
+        result.startsWith("{") && result.endsWith("}"));
+    assertTrue("Should contain userLists object", result.contains("UserLists:"));
+  }
+
+  public void testDoPostBadRequest() throws ServletException, IOException {
+    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
+    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
+    StringWriter writer = new StringWriter();
+    StringReader reader = new StringReader("{\"bad response\" list:\"bread\"}");
+    CreateOrUpdateUserlistServlet servlet = new GetUserListsServlet();
+
+    Mockito.when(req.getMethod()).thenReturn("POST");
+    Mockito.when(req.getReader()).thenReturn(new BufferedReader(reader));
+    Mockito.when(res.getWriter()).thenReturn(new PrintWriter(writer));
+
+    servlet.doPost(req, res);
+
+    Mockito.verify(res).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    String result = writer.toString();
+    assertTrue("Should say invalid syntax", result.contains("Invalid request syntax."));
+  }
+}

--- a/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
+++ b/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
@@ -1,3 +1,4 @@
+import com.google.gson.Gson;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.BufferedReader;
@@ -35,8 +36,6 @@ public class GetUserListsServletTest extends TestCase {
 
     Mockito.verify(setupObj.response).setStatus(HttpServletResponse.SC_OK);
     String result = setupObj.writer.toString();
-    assertTrue("should be valid json format", 
-        result.startsWith("{") && result.endsWith("}"));
     assertTrue("Should contain userLists object", result.contains("UserLists:"));
   }
 
@@ -48,6 +47,7 @@ public class GetUserListsServletTest extends TestCase {
 
     Mockito.verify(setupObj.response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
     String result = setupObj.writer.toString();
+    assertTrue("Is valid json format", isValidJson(result));
     assertTrue("Should say invalid syntax", result.contains("Invalid request syntax."));
   }
 
@@ -60,5 +60,15 @@ public class GetUserListsServletTest extends TestCase {
     Mockito.when(req.getReader()).thenReturn(new BufferedReader(reader));
     Mockito.when(res.getWriter()).thenReturn(new PrintWriter(writer));
     return new SetupObj(req, res, writer);
+  }
+
+  private static boolean isValidJson(String str) {
+    Gson g = new Gson();
+    try {
+      g.fromJson(str, Object.class);
+      return true;
+    } catch(com.google.gson.JsonSyntaxException e) { 
+      return false;
+    }
   }
 }

--- a/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
+++ b/capstone/backend/src/test/java/com/google/GetUserListsServletTest.Java
@@ -11,41 +11,54 @@ import junit.framework.TestCase;
 import org.mockito.Mockito;
 
 public class GetUserListsServletTest extends TestCase {
+  private static final String CORRECT_REQUEST_STRING = "{\"userId\": 1}";
+  private static final String INCORRECT_REQUEST_STRING = "{\"bad response\" list:\"bread\"}";
+
+  private class SetupObj {
+    HttpServletRequest request;
+    HttpServletResponse response;
+    StringWriter writer;
+
+    public SetupObj(HttpServletRequest request, HttpServletResponse response, 
+        StringWriter writer) {
+      this.request = request;
+      this.response = response;
+      this.writer = writer;
+    }
+  }
+
   public void testDoPostSucceed() throws ServletException, IOException {
-    HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
-    HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
-    StringWriter writer = new StringWriter();
-    StringReader reader = new StringReader(
-        "{\"userId\": 1}");
+    SetupObj setupObj = setupMockData(CORRECT_REQUEST_STRING);
+
     CreateOrUpdateUserlistServlet servlet = new GetUserListsServlet();
+    servlet.doPost(setupObj.request, setupObj.response);
 
-    Mockito.when(req.getMethod()).thenReturn("POST");
-    Mockito.when(req.getReader()).thenReturn(new BufferedReader(reader));
-    Mockito.when(res.getWriter()).thenReturn(new PrintWriter(writer));
-
-    servlet.doPost(req, res);
-    Mockito.verify(res).setStatus(HttpServletResponse.SC_OK);
-    String result = writer.toString();
+    Mockito.verify(setupObj.response).setStatus(HttpServletResponse.SC_OK);
+    String result = setupObj.writer.toString();
     assertTrue("should be valid json format", 
         result.startsWith("{") && result.endsWith("}"));
     assertTrue("Should contain userLists object", result.contains("UserLists:"));
   }
 
   public void testDoPostBadRequest() throws ServletException, IOException {
+    SetupObj = setupMockData(INCORRECT_REQUEST_STRING);
+
+    CreateOrUpdateUserlistServlet servlet = new GetUserListsServlet();
+    servlet.doPost(setupObj.request, setupObj.response);
+
+    Mockito.verify(setupObj.response).setStatus(HttpServletResponse.SC_BAD_REQUEST);
+    String result = setupObj.writer.toString();
+    assertTrue("Should say invalid syntax", result.contains("Invalid request syntax."));
+  }
+
+  public SetupObj setupMockData(String reqString) {
     HttpServletRequest req = Mockito.mock(HttpServletRequest.class);
     HttpServletResponse res = Mockito.mock(HttpServletResponse.class);
     StringWriter writer = new StringWriter();
-    StringReader reader = new StringReader("{\"bad response\" list:\"bread\"}");
-    CreateOrUpdateUserlistServlet servlet = new GetUserListsServlet();
-
+    StringReader reader = new StringReader(reqString);
     Mockito.when(req.getMethod()).thenReturn("POST");
     Mockito.when(req.getReader()).thenReturn(new BufferedReader(reader));
     Mockito.when(res.getWriter()).thenReturn(new PrintWriter(writer));
-
-    servlet.doPost(req, res);
-
-    Mockito.verify(res).setStatus(HttpServletResponse.SC_BAD_REQUEST);
-    String result = writer.toString();
-    assertTrue("Should say invalid syntax", result.contains("Invalid request syntax."));
+    return new SetupObj(req, res, writer);
   }
 }


### PR DESCRIPTION
Added a function that handles a GET request to "/api/v1/get-user=lists". This function calls getUserLists() function from the Spanner Util functions to obtain the saved user's saved lists from the database. These are returned in the response in JSON format. 

Added two unit tests. One checks to see that the response contains the UserLists object on a successful execution and the other checks to see if the response contains an error message when there request has invalid syntax. 