### PR TITLE
Stores page

### DIFF
--- a/capstone/client/package.json
+++ b/capstone/client/package.json
@@ -10,6 +10,7 @@
     "@testing-library/react": "^9.3.2",
     "@testing-library/user-event": "^7.1.2",
     "axios": "^0.19.2",
+    "google-maps-react": "^2.0.6",
     "react": "^16.13.1",
     "react-dom": "^16.13.1",
     "react-google-login": "^5.1.21",

--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+import { Map, GoogleApiWrapper } from 'google-maps-react';
+
+class StoreDetailCards extends Component {
+    constructor(props) {
+      super(props);
+    }
+
+    render() {
+        const storeDetailCards = this.props.stores.map((store) => (
+            <div>
+              <Typography variant='h4'>{store.storeName}</Typography>
+              <Typography variant='h6'>Address: {store.address}</Typography>
+              <Grid container alignItems="stretch">
+                <Grid xs>
+                  <Map google={this.props.google} zoom={14} style={{width: '25%', height: '25%'}}>
+                  </Map>
+                </Grid>
+                <Grid xs>
+                  <Typography variant='subtitle1'>Has:</Typography>
+                  <List>
+                  {Object.keys(store.items).map((itemType, item) => (
+                    <ListItem>
+                      <ListItemText>
+                        {item.itemName} (${item.itemPrice})
+                      </ListItemText>
+                    </ListItem>
+                  ))}
+                  </List>
+                </Grid>
+              </Grid>
+            </div>
+          ));
+        return (
+            <div>
+              {storeDetailCards[0]}
+            </div>
+        )
+    }
+}
+
+export default StoreDetailCards;

--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -17,6 +17,7 @@
 import React, { Component } from 'react';
 import { Grid, Typography, List, ListItem, ListItemText } from '@material-ui/core';
 import { Map } from 'google-maps-react';
+import './styles.css';
 
 class StoreDetailCards extends Component {
 
@@ -27,7 +28,7 @@ class StoreDetailCards extends Component {
               <Typography variant='h6'>Address: {store.address}</Typography>
               <Grid container alignItems="stretch">
                 <Grid xs>
-                  <Map google={this.props.google} zoom={14} style={{width: '25%', height: '25%'}}>
+                  <Map id="google-map" google={this.props.google} zoom={14}>
                   </Map>
                 </Grid>
                 <Grid xs>

--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -15,13 +15,10 @@
  */
 
 import React, { Component } from 'react';
-import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
-import { Map, GoogleApiWrapper } from 'google-maps-react';
+import { Grid, Typography, List, ListItem, ListItemText } from '@material-ui/core';
+import { Map } from 'google-maps-react';
 
 class StoreDetailCards extends Component {
-    constructor(props) {
-      super(props);
-    }
 
     render() {
         const storeDetailCards = this.props.stores.map((store) => (

--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+
+class StoreOverviewCards extends Component {
+    constructor(props) {
+      super(props);
+    }
+
+    render() {
+        const storeOverviewCards = this.props.stores.map((store) => (
+            <div>
+              <Typography variant="h6">{store.storeName}</Typography>
+              <List>
+              <ListItem>
+                  <ListItemText>
+                  Has: {store.totalItemsFound}/6
+                  </ListItemText>
+              </ListItem>
+              <ListItem>
+                  <ListItemText>
+                  Lowest Potential Price: ${store.lowestPotentialPrice}
+                  </ListItemText>
+              </ListItem>
+              <ListItem>
+                  <ListItemText>
+                  Distance: 5 miles
+                  </ListItemText>
+              </ListItem>
+              </List>
+              <Button variant="contained" color="primary">
+                Show more Information
+              </Button>
+            </div>
+        ));
+        return (
+            <div>
+              {storeOverviewCards}
+            </div>
+        )
+    }
+}
+
+export default StoreOverviewCards;

--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -16,6 +16,7 @@
 
 import React, { Component } from 'react';
 import { Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+import './styles.css';
 
 class StoreOverviewCards extends Component {
 

--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -15,12 +15,9 @@
  */
 
 import React, { Component } from 'react';
-import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+import { Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
 
 class StoreOverviewCards extends Component {
-    constructor(props) {
-      super(props);
-    }
 
     render() {
         const storeOverviewCards = this.props.stores.map((store) => (

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -58,7 +58,16 @@ class StorePage extends Component {
     componentWillMount = () => {
         // Get Stores from database.
         this.getStores();
-      }
+    }
+
+    getStores = () => {
+      axios.get('/api/v1/get-stores-with-item-types', { params : { item_types : itemList }})
+        .then(res => {
+          this.setState({
+            stores: res.data.stores
+          });
+        });
+    }
 
     render() {
 

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -21,28 +21,6 @@ import { Map, GoogleApiWrapper } from 'google-maps-react';
 
 import { Store } from './Store';
 
-const stores = [{
-    name: 'Safeway',
-    address: '11050 Bollinger Canyon Rd, San Ramon',
-    totalItemsFound: 5,
-    items: [{name: 'O Organics Organic Whole Milk with Vitamin D - 1 Gallon', price: 4.55}, 
-      {name: 'Lucerne Milk Reduced Fat 2% Milkfat 1 Gallon - 128 Fl. Oz.', price: 2.55},
-      {name: 'Silk Almondmilk Original Unsweetened - Half Gallon', price: 4.33}],
-    distance: 3.1,
-    price: 8.96
-}, 
-{
-    name: 'Walmart',
-    address: '9100 Alcosta Blvd, San Ramon',
-    totalItemsFound: 2,
-    items: [{name: 'O Organics Organic Whole Milk with Vitamin D - 1 Gallon', price: 4.55}, 
-      {name: 'Lucerne Milk Reduced Fat 2% Milkfat 1 Gallon - 128 Fl. Oz.', price: 2.55},
-      {name: 'Silk Almondmilk Original Unsweetened - Half Gallon', price: 1.44}],
-    distance: 2.3,
-    price: 16.45,
-}
-]
-
 const itemList = [
     "Milk",
     "Bread"

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -20,6 +20,7 @@ import { Grid, Card} from '@material-ui/core';
 import { GoogleApiWrapper } from 'google-maps-react';
 
 import { Store } from './Store';
+import APIKey from './APIKey.js';
 import StoreOverviewCards from './StoreOverviewCards.js';
 import StoreDetailCards from './StoreDetailCards.js';
 
@@ -71,5 +72,5 @@ class StorePage extends Component {
 }
 
 export const StorePageWithStore = GoogleApiWrapper({
-  apiKey: ('AIzaSyAmMqit2VT4XMp0W2imrYduF8WmhLDPQgk')
+  apiKey: (APIKey.APIKey())
 })(Store.withStore(StorePage))

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -23,6 +23,7 @@ import { Store } from './Store';
 import APIKey from './APIKey.js';
 import StoreOverviewCards from './StoreOverviewCards.js';
 import StoreDetailCards from './StoreDetailCards.js';
+import './styles.css';
 
 
 const itemList = [

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -15,6 +15,7 @@
  */
 
 import React, { Component } from 'react';
+import axios from 'axios';
 import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
 import { Map, GoogleApiWrapper } from 'google-maps-react';
 
@@ -51,8 +52,9 @@ class StorePage extends Component {
     constructor(props) {
       super(props)
       this.state = {
-          stores = []
+          stores : []
       }
+      this.getStores();
     }
 
     componentWillMount = () => {
@@ -64,30 +66,30 @@ class StorePage extends Component {
       axios.get('/api/v1/get-stores-with-item-types', { params : { item_types : itemList }})
         .then(res => {
           this.setState({
-            stores: res.data.stores
+            stores: res.data
           });
         });
     }
 
     render() {
 
-      const storeOverviewCards = stores.map((store) => (
+      const storeOverviewCards = this.state.stores.map((store) => (
           <div>
-            <Typography variant="h6">{store.name}</Typography>
+            <Typography variant="h6">{store.storeName}</Typography>
             <List>
             <ListItem>
                 <ListItemText>
-                Has: {store.totalItemsFound}/6 items
+                Has: {store.totalItemsFound}/{itemList.length}
                 </ListItemText>
             </ListItem>
             <ListItem>
                 <ListItemText>
-                Price: ${store.price}
+                Lowest Potential Price: ${store.lowestPotentialPrice}
                 </ListItemText>
             </ListItem>
             <ListItem>
                 <ListItemText>
-                Distance: {store.distance} miles
+                Distance: 5 miles
                 </ListItemText>
             </ListItem>
             </List>
@@ -98,7 +100,7 @@ class StorePage extends Component {
       ));
 
 
-      const storeDetailCards = stores.map((store) => (
+      const storeDetailCards = this.state.stores.map((store) => (
         <div>
           <Typography variant='h4'>{store.name}</Typography>
           <Typography variant='h6'>Address: {store.address}</Typography>
@@ -110,10 +112,10 @@ class StorePage extends Component {
             <Grid xs>
               <Typography variant='subtitle1'>Has:</Typography>
               <List>
-              {store.items.map((item) => (
+              {Object.keys(store.items).map((itemType, item) => (
                 <ListItem>
                   <ListItemText>
-                    {item.name} (${item.price})
+                    {item.itemName} (${item.itemPrice})
                   </ListItemText>
                 </ListItem>
               ))}

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -16,8 +16,8 @@
 
 import React, { Component } from 'react';
 import axios from 'axios';
-import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
-import { Map, GoogleApiWrapper } from 'google-maps-react';
+import { Grid, Card} from '@material-ui/core';
+import { GoogleApiWrapper } from 'google-maps-react';
 
 import { Store } from './Store';
 import StoreOverviewCards from './StoreOverviewCards.js';

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -1,0 +1,135 @@
+/*
+ * Copyright 2020 Google Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React, { Component } from 'react';
+import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+import { Map, GoogleApiWrapper } from 'google-maps-react';
+
+import { Store } from './Store';
+
+const stores = [{
+    name: 'Safeway',
+    address: '11050 Bollinger Canyon Rd, San Ramon',
+    totalItemsFound: 5,
+    items: [{name: 'O Organics Organic Whole Milk with Vitamin D - 1 Gallon', price: 4.55}, 
+      {name: 'Lucerne Milk Reduced Fat 2% Milkfat 1 Gallon - 128 Fl. Oz.', price: 2.55},
+      {name: 'Silk Almondmilk Original Unsweetened - Half Gallon', price: 4.33}],
+    distance: 3.1,
+    price: 8.96
+}, 
+{
+    name: 'Walmart',
+    address: '9100 Alcosta Blvd, San Ramon',
+    totalItemsFound: 2,
+    items: [{name: 'O Organics Organic Whole Milk with Vitamin D - 1 Gallon', price: 4.55}, 
+      {name: 'Lucerne Milk Reduced Fat 2% Milkfat 1 Gallon - 128 Fl. Oz.', price: 2.55},
+      {name: 'Silk Almondmilk Original Unsweetened - Half Gallon', price: 1.44}],
+    distance: 2.3,
+    price: 16.45,
+}
+]
+
+const itemList = [
+    "Milk",
+    "Bread"
+]
+
+class StorePage extends Component { 
+    constructor(props) {
+      super(props)
+      this.state = {
+          stores = []
+      }
+    }
+
+    componentWillMount = () => {
+        // Get Stores from database.
+        this.getStores();
+      }
+
+    render() {
+
+      const storeOverviewCards = stores.map((store) => (
+          <div>
+            <Typography variant="h6">{store.name}</Typography>
+            <List>
+            <ListItem>
+                <ListItemText>
+                Has: {store.totalItemsFound}/6 items
+                </ListItemText>
+            </ListItem>
+            <ListItem>
+                <ListItemText>
+                Price: ${store.price}
+                </ListItemText>
+            </ListItem>
+            <ListItem>
+                <ListItemText>
+                Distance: {store.distance} miles
+                </ListItemText>
+            </ListItem>
+            </List>
+            <Button variant="contained" color="primary">
+              Show more Information
+            </Button>
+          </div>
+      ));
+
+
+      const storeDetailCards = stores.map((store) => (
+        <div>
+          <Typography variant='h4'>{store.name}</Typography>
+          <Typography variant='h6'>Address: {store.address}</Typography>
+          <Grid container alignItems="stretch">
+            <Grid xs>
+              <Map google={this.props.google} zoom={14} style={{width: '25%', height: '25%'}}>
+              </Map>
+            </Grid>
+            <Grid xs>
+              <Typography variant='subtitle1'>Has:</Typography>
+              <List>
+              {store.items.map((item) => (
+                <ListItem>
+                  <ListItemText>
+                    {item.name} (${item.price})
+                  </ListItemText>
+                </ListItem>
+              ))}
+              </List>
+            </Grid>
+          </Grid>
+        </div>
+      ));
+
+      return(
+        <div>
+          <h1>Store Recommendations</h1>
+          <Grid container alignItems="stretch">
+            <Grid item component={Card} xs>
+              {storeOverviewCards}
+            </Grid>
+            <Grid item component={Card} xs>
+              {storeDetailCards[0]}
+            </Grid>
+          </Grid>
+        </div>
+      )
+    }
+}
+
+export const StorePageWithStore = GoogleApiWrapper({
+  apiKey: ('AIzaSyAmMqit2VT4XMp0W2imrYduF8WmhLDPQgk')
+})(Store.withStore(StorePage))

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -20,6 +20,9 @@ import { Grid, Card, Typography, List, ListItem, ListItemText, Button } from '@m
 import { Map, GoogleApiWrapper } from 'google-maps-react';
 
 import { Store } from './Store';
+import StoreOverviewCards from './StoreOverviewCards.js';
+import StoreDetailCards from './StoreDetailCards.js';
+
 
 const itemList = [
     "Milk",
@@ -32,7 +35,7 @@ class StorePage extends Component {
       this.state = {
           stores : []
       }
-      this.getStores();
+      this.getStores = this.getStores.bind(this);
     }
 
     componentWillMount = () => {
@@ -51,67 +54,15 @@ class StorePage extends Component {
 
     render() {
 
-      const storeOverviewCards = this.state.stores.map((store) => (
-          <div>
-            <Typography variant="h6">{store.storeName}</Typography>
-            <List>
-            <ListItem>
-                <ListItemText>
-                Has: {store.totalItemsFound}/{itemList.length}
-                </ListItemText>
-            </ListItem>
-            <ListItem>
-                <ListItemText>
-                Lowest Potential Price: ${store.lowestPotentialPrice}
-                </ListItemText>
-            </ListItem>
-            <ListItem>
-                <ListItemText>
-                Distance: 5 miles
-                </ListItemText>
-            </ListItem>
-            </List>
-            <Button variant="contained" color="primary">
-              Show more Information
-            </Button>
-          </div>
-      ));
-
-
-      const storeDetailCards = this.state.stores.map((store) => (
-        <div>
-          <Typography variant='h4'>{store.name}</Typography>
-          <Typography variant='h6'>Address: {store.address}</Typography>
-          <Grid container alignItems="stretch">
-            <Grid xs>
-              <Map google={this.props.google} zoom={14} style={{width: '25%', height: '25%'}}>
-              </Map>
-            </Grid>
-            <Grid xs>
-              <Typography variant='subtitle1'>Has:</Typography>
-              <List>
-              {Object.keys(store.items).map((itemType, item) => (
-                <ListItem>
-                  <ListItemText>
-                    {item.itemName} (${item.itemPrice})
-                  </ListItemText>
-                </ListItem>
-              ))}
-              </List>
-            </Grid>
-          </Grid>
-        </div>
-      ));
-
       return(
         <div>
           <h1>Store Recommendations</h1>
           <Grid container alignItems="stretch">
             <Grid item component={Card} xs>
-              {storeOverviewCards}
+              <StoreOverviewCards stores={this.state.stores}/>
             </Grid>
             <Grid item component={Card} xs>
-              {storeDetailCards[0]}
+              <StoreDetailCards stores={this.state.stores}/>
             </Grid>
           </Grid>
         </div>

--- a/capstone/client/src/components/WebRouter.js
+++ b/capstone/client/src/components/WebRouter.js
@@ -20,6 +20,7 @@ import { Switch, Route, BrowserRouter as Router } from 'react-router-dom';
 import { ListPageWithStore } from './ListPage.js';
 import { HeaderWithStore } from './Header.js';
 import { Store } from './Store';
+import { StorePageWithStore } from './StoresPage';
 
 function WebRouter() {
   return (
@@ -29,6 +30,7 @@ function WebRouter() {
           <HeaderWithStore />
           <Switch>
             <Route exact path='/' component={() => <ListPageWithStore />} />
+            <Route path='/storepage' component={() => <StorePageWithStore/>} />
           </Switch>
         </Store.Container>
       </Router>

--- a/capstone/client/src/components/WebRouter.js
+++ b/capstone/client/src/components/WebRouter.js
@@ -30,7 +30,7 @@ function WebRouter() {
           <HeaderWithStore />
           <Switch>
             <Route exact path='/' component={() => <ListPageWithStore />} />
-            <Route path='/storepage' component={() => <StorePageWithStore/>} />
+            <Route path='/stores' component={() => <StorePageWithStore/>} />
           </Switch>
         </Store.Container>
       </Router>

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -67,3 +67,12 @@ h1 {
 }
 
 /* ListPage end */
+
+/* StoreDetailCards start */
+
+#google-map {
+  height : 25%;
+  width : 25%;
+}
+
+/* StoreDetailCards end */


### PR DESCRIPTION
Used Anudeep's skeleton code to continue development on the StoresPage.

<img width="1486" alt="Screen Shot 2020-07-15 at 11 36 17 PM" src="https://user-images.githubusercontent.com/51011816/87635537-154e6300-c6f4-11ea-8730-bea55687e670.png">

Major Changes:

I separated the store overview cards and the store detail cards into two different components and files that are then imported and used in the main page.

Additionally, I incorporated the get-stores-with-item-types API so we are retrieving legitimate data. (the only downside here is that the code uses a preprogrammed ItemTypes list of strings, which will obviously need to be fixed in future development)

Also, not sure why it says the map is loading but that will also need to be fixed