### PR TITLE
Update the Walmart scraper for item availability and prices.

### DIFF
--- a/capstone/backend/scraper/scrapers/safeway_scraper.py
+++ b/capstone/backend/scraper/scrapers/safeway_scraper.py
@@ -21,7 +21,7 @@ from selenium.webdriver.support.ui import WebDriverWait
 from write_to_spanner import write_item_info_to_inventory_table, write_item_info_to_items_table, write_store_info_to_stores_table
 
 FLAGS = flags.FLAGS
-flags.DEFINE_boolean('test', False, 'Doesn\'t write items to Spaner.')
+flags.DEFINE_boolean('test', False, 'Doesn\'t write items to Spanner.')
 
 AVALIBILITY_KEY = 'availability'
 CHROME_DRIVER_PATH = '/Users/anudeepyakkala/Downloads/chromedriver'

--- a/capstone/backend/scraper/scrapers/scraper.py
+++ b/capstone/backend/scraper/scrapers/scraper.py
@@ -92,6 +92,17 @@ class Scraper:
    
     return inventory_dict
 
+def set_items_unavailable_default(transaction):
+  """ Sets all item availabilities to OUT_OF_STOCK.
+  This function marks items that no longer appear 
+  in stores out of stock, as opposed to their old 
+  availability statuses."""
+  transaction.execute_update(
+    "UPDATE Inventories "
+    "SET ItemAvailability = 'OUT_OF_STOCK' "
+    "WHERE ItemAvailability IS NOT NULL"
+  )
+
 def main(argv):
   if len(argv) > 1:
     raise app.UsageError('Too many command-line arguments.')
@@ -130,6 +141,9 @@ def main(argv):
   # Get a Cloud Spanner database by ID.
   database = instance.database(_DATABASE_ID)
 
+  # Set all items to default OUT_OF_STOCK.
+  database.run_in_transaction(set_items_unavailable_default)
+
   # Keep a list of unique ItemIds
   item_ids = []
 
@@ -138,37 +152,39 @@ def main(argv):
       soup = Scraper.get_page('https://www.walmart.com/search/?grid=false&query=' + type.replace(' ', '+') + '&stores=' + store)
       items = Scraper.get_items(soup)
       for item in items:
-        # Check if we have recorded this item before.
-        if 'productId' in item:
-          if item['productId'] not in item_ids:
-            item_ids.append(item['productId'])
-            item_info = Scraper.get_item_info(item)
-            item_info['ItemType'] = type
-            with database.batch() as batch:
-              """ batch.replace() inserts or updates one or more 
-              records in a table. Existing rows have values
-              for supplied columns overwritten; ther column values
-              set to null. 
-              """
-              batch.replace(
-                table = 'Items',
-                columns = items_cols,
-                values = [
-                  item_info.values()
-                ]
-              )
-
-        inventory_info = Scraper.get_inventory_info(item)
-        inventory_info['StoreId'] = int(store)
-        inventory_info['LastUpdated'] = spanner.COMMIT_TIMESTAMP
-        with database.batch() as batch:
-          batch.replace(
-            table = 'Inventories',
-            columns = inventories_cols,
-            values = [
-              inventory_info.values()
-            ]
-          )
+        # If the price is null, do not record the item.
+        if 'primaryOffer' in item and 'offerPrice' in item['primaryOffer']:
+          # Check if we have recorded this item in another store before.
+          if 'productId' in item:
+            if item['productId'] not in item_ids:
+              item_ids.append(item['productId'])
+              item_info = Scraper.get_item_info(item)
+              item_info['ItemType'] = type
+              with database.batch() as batch:
+                """ batch.replace() inserts or updates one or more 
+                records in a table. Existing rows have values
+                for supplied columns overwritten; ther column values
+                set to null. 
+                """
+                batch.replace(
+                  table = 'Items',
+                  columns = items_cols,
+                  values = [
+                    item_info.values()
+                  ]
+                )
+        
+          inventory_info = Scraper.get_inventory_info(item)
+          inventory_info['StoreId'] = int(store)
+          inventory_info['LastUpdated'] = spanner.COMMIT_TIMESTAMP
+          with database.batch() as batch:
+            batch.replace(
+              table = 'Inventories',
+              columns = inventories_cols,
+              values = [
+                inventory_info.values()
+              ]
+            )
 
 if __name__ == '__main__':
   app.run(main)

--- a/capstone/backend/scraper/scrapers/scraper.py
+++ b/capstone/backend/scraper/scrapers/scraper.py
@@ -99,8 +99,10 @@ def set_items_unavailable_default(transaction):
   availability statuses."""
   transaction.execute_update(
     "UPDATE Inventories "
-    "SET ItemAvailability = 'OUT_OF_STOCK' "
-    "WHERE ItemAvailability IS NOT NULL"
+    "SET ItemAvailability = \'OUT_OF_STOCK\' "
+    "WHERE StoreId IN UNNEST(@stores)",
+    params={'stores': [2486, 2119, 2280, 3123, 4174]},
+    param_types={'stores': spanner.param_types.Array(spanner.param_types.INT64)}
   )
 
 def main(argv):

--- a/capstone/backend/scraper/scrapers/scraper.py
+++ b/capstone/backend/scraper/scrapers/scraper.py
@@ -92,6 +92,7 @@ class Scraper:
    
     return inventory_dict
 
+# TODO(carolynlwang): Add stores as a parameter, as opposed to hard-coded in params.
 def set_items_unavailable_default(transaction):
   """ Sets all item availabilities to OUT_OF_STOCK.
   This function marks items that no longer appear 
@@ -144,7 +145,7 @@ def main(argv):
   database = instance.database(_DATABASE_ID)
 
   # Set all items to default OUT_OF_STOCK.
-  database.run_in_transaction(set_items_unavailable_default)
+  database.run_in_transaction(set_items_unavailable_default())
 
   # Keep a list of unique ItemIds
   item_ids = []

--- a/capstone/backend/scraper/test/scraper_test.py
+++ b/capstone/backend/scraper/test/scraper_test.py
@@ -6,7 +6,7 @@ First, navigate to step39-2020/capstone/backend/
 python3 -m scraper.test.scraper_test
 """
 
-from .. import scraper
+from ..scrapers import scraper
 from bs4 import BeautifulSoup
 from datetime import datetime
 import json


### PR DESCRIPTION
Updated to comply with GetStoreRankings API. 
If items don't have prices, then do not record them in the scraping process.
Also updated so that all Walmart items in the current inventories are set to default OUT OF STOCK, then updated with the display flag that the scraping finds. For instance, if there's item A AVAILABLE in the database as of yesterday, but it's no longer on the website today, the ItemAvailability will now be OUT_OF_STOCK, as opposed to the old code, which would have left it as AVAILABLE. 