### PR TITLE
Styling changes to store overview

### DIFF
--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -35,7 +35,7 @@ class StoreOverviewCards extends Component {
                     <ShoppingCartIcon color='primary' />
                   </ListItemIcon>
                   <ListItemText>
-                  Has: {store.totalItemsFound}/{this.props.numItems}
+                  Total Items Found: {store.totalItemsFound}/{this.props.numItems}
                   </ListItemText>
               </ListItem>
               <ListItem>

--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -15,7 +15,10 @@
  */
 
 import React, { Component } from 'react';
-import { Typography, List, ListItem, ListItemText, Button } from '@material-ui/core';
+import { Typography, List, ListItem, ListItemIcon, ListItemText, Button } from '@material-ui/core';
+import ShoppingCartIcon from '@material-ui/icons/ShoppingCart';
+import AttachMoneyIcon from '@material-ui/icons/AttachMoney';
+import DriveEtaIcon from '@material-ui/icons/DriveEta';
 
 import { StoresContext } from './StoresProvider.js';
 import './styles.css';
@@ -24,20 +27,29 @@ class StoreOverviewCards extends Component {
 
     render() {
         const storeOverviewCards = this.props.stores.map((store, index) => (
-            <div>
-              <Typography variant="h6">{store.storeName}</Typography>
+            <div id="store-overview-card">
+              <Typography variant="h6" component="h6">{store.storeName}</Typography>
               <List>
               <ListItem>
+                  <ListItemIcon>
+                    <ShoppingCartIcon color='primary' />
+                  </ListItemIcon>
                   <ListItemText>
-                  Has: {store.totalItemsFound}/6
+                  Has: {store.totalItemsFound}/{this.props.numItems}
                   </ListItemText>
               </ListItem>
               <ListItem>
+                  <ListItemIcon>
+                    <AttachMoneyIcon color='primary' />
+                  </ListItemIcon>
                   <ListItemText>
                   Lowest Potential Price: ${store.lowestPotentialPrice}
                   </ListItemText>
               </ListItem>
               <ListItem>
+                  <ListItemIcon>
+                    <DriveEtaIcon color='primary' />
+                  </ListItemIcon>
                   <ListItemText>
                   Distance: 5 miles
                   </ListItemText>
@@ -45,7 +57,7 @@ class StoreOverviewCards extends Component {
               </List>
               <StoresContext.Consumer>
                   {(context) => (
-                    <Button variant="contained" color="primary" onClick={() => 
+                    <Button id="show-more-info" variant="contained" color="primary" onClick={() => 
                       context.setStore(index)}>
                     Show more Information
                     </Button>

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -73,7 +73,7 @@ class StorePage extends Component {
         <StoresProvider>
         <Grid container alignItems="stretch">
           <Grid item component={Card} xs>
-            <StoreOverviewCards stores={this.state.stores}/>
+            <StoreOverviewCards stores={this.state.stores} numItems={this.state.items.length}/>
           </Grid>
           <Grid item component={Card} xs>
             <StoreDetailCards stores={this.state.stores} style={{display: 'none'}}/>

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -24,6 +24,10 @@ h1 {
   text-align: center;
 }
 
+h6 {
+  font-weight: 600;
+}
+
 /* Header start */
 
 #typography {
@@ -67,6 +71,20 @@ h1 {
 }
 
 /* ListPage end */
+
+/* StoreOverviewCards start */
+
+#show-more-info {
+  margin-left: 20%;
+  margin-right: 20%;
+  width: 60%;
+}
+
+#store-overview-card {
+  padding: 20px;
+}
+
+/* StoreOverviewCards end */
 
 /* StoreDetailCards start */
 


### PR DESCRIPTION
Altered store overview to accurately show the number of total items, it used to just say 6 by default.

Added some icons and changed alignment to be more centered and normal looking

Styling is in styles.css

<img width="501" alt="Screen Shot 2020-07-20 at 7 11 46 PM" src="https://user-images.githubusercontent.com/51011816/88005015-27961b80-cabd-11ea-969d-b76d2e539dd2.png">

