### PR TITLE
Truncate long floats

### DIFF
--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -17,7 +17,7 @@
 import React, { Component } from 'react';
 import {Redirect} from 'react-router-dom';
 import axios from 'axios';
-import { Button, ButtonGroup, Card, Checkbox, Dialog, DialogActions,DialogContent, DialogContentText, 
+import { Button, ButtonGroup, Card, Checkbox, CircularProgress, Dialog, DialogActions,DialogContent, DialogContentText, 
   DialogTitle, FormGroup, FormControlLabel, Grid, List,
   Radio, RadioGroup, TextField } 
   from '@material-ui/core';
@@ -279,7 +279,7 @@ class ListPage extends Component {
     <Button name={index}>{userList.displayName}</Button>
     ));
 
-    const checkboxItems = this.state.items.map((item) => (
+    const checkboxItems = (this.state.items.length === 0) ? <CircularProgress id="loading-spinner" color="action" /> : this.state.items.map((item) => (
       <FormControlLabel
         control={<Checkbox name={item} ref={component => this.itemsToComponent[item] = component} data-testid='checkbox item'/>}
         label={item}

--- a/capstone/client/src/components/StoreOverviewCards.js
+++ b/capstone/client/src/components/StoreOverviewCards.js
@@ -43,7 +43,7 @@ class StoreOverviewCards extends Component {
                     <AttachMoneyIcon color='primary' />
                   </ListItemIcon>
                   <ListItemText>
-                  Lowest Potential Price: ${store.lowestPotentialPrice}
+                  Lowest Potential Price: ${(store.lowestPotentialPrice-.005).toFixed(2)}
                   </ListItemText>
               </ListItem>
               <ListItem>

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -65,6 +65,10 @@ h6 {
   margin-left: 5%;
 }
 
+#loading-spinner {
+  margin-left: 40%;
+  margin-bottom: 10px;
+}
 
 #submit-button {
   margin-bottom: 20px;


### PR DESCRIPTION
Cuts off long extensions on potentially long floating point prices

also added loading screen

<img width="783" alt="Screen Shot 2020-07-21 at 6 46 18 PM" src="https://user-images.githubusercontent.com/51011816/88124801-cdf82480-cb82-11ea-8ff4-f1f911e2c516.png">
