### PR TITLE
Set default lat and lon, fixed price truncation for store details

### DIFF
--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -44,7 +44,7 @@ class ListPage extends Component {
       listName: null,
       userId: -1,
       displayZipCodeInput: false,
-      location: {
+      location: { // San Jose by default
         latitude: 37.338207,
         longitude: -121.886330,
       },

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -44,7 +44,10 @@ class ListPage extends Component {
       listName: null,
       userId: -1,
       displayZipCodeInput: false,
-      location: null,
+      location: {
+        latitude: 37.338207,
+        longitude: -121.886330,
+      },
       listSaveDialog: {
         display: false,
       },

--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -44,7 +44,7 @@ class StoreDetailCards extends Component {
                 <div>{Object.keys(store.items[itemType]).map((index, i) => (
                   <ListItem key = {i}>
                   <ListItemText>
-                    {store.items[itemType][index].itemName} (${store.items[itemType][index].itemPrice})
+                    {store.items[itemType][index].itemName} (${(store.items[itemType][index].itemPrice-.005).toFixed(2)})
                   </ListItemText>
                 </ListItem>
                 ))}


### PR DESCRIPTION
I changed so that the default latitude and longitude are set to the center of san jose in case the user never allows their location to be tracked it will not cause a bug and instead just return some default values. (this tactic is used by Yelp)

I also fixed the truncation issue with the store details page