### PR TITLE
Added spinning wheel for when stores are loading

### DIFF
--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -301,6 +301,8 @@ class ListPage extends Component {
         />
     ));
 
+    const saveButton = (this.state.userId === -1) ? <div></div> : <Button onClick={this.onSave} color="secondary" variant="contained">Save List</Button>;
+
     return (
       <div id="list-page-container">
         {this.state.errorMessage ? <Alert severity="error">{this.state.errorMessage}</Alert> : null}
@@ -321,7 +323,7 @@ class ListPage extends Component {
             <FormGroup id="items-list">
               {checkboxItems}
             </FormGroup>
-            <Button onClick={this.onSave} color="secondary" variant="contained">Save List</Button>
+            {saveButton}
             <List>
               {this.state.selectedItemsList}
             </List>

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -16,7 +16,7 @@
 
 import axios from 'axios';
 import {Redirect} from 'react-router-dom';
-import { Button, Card, Grid } from '@material-ui/core';
+import { Button, Card, CircularProgress, Grid } from '@material-ui/core';
 import React, { Component } from 'react';
 
 import { Store } from './Store';
@@ -82,6 +82,9 @@ class StorePage extends Component {
       }}/>
     }
 
+    const overviewCards = (this.state.stores.length === 0) ? <CircularProgress id="stores-loading" color="action" /> : 
+    <StoreOverviewCards stores={this.state.stores} numItems={this.state.items.length}/>;
+
     return(
       <div id="stores-page-container">
         <h1>Store Recommendations</h1>
@@ -90,7 +93,7 @@ class StorePage extends Component {
         <Grid container alignItems="stretch">
           <Grid item component={Card} xs>
             <FilterStores originalStores={this.state.originalStores} items={this.state.items} onFilterChange={this.handleFilterchange}/>
-            <StoreOverviewCards stores={this.state.stores} numItems={this.state.items.length}/>
+            {overviewCards}
           </Grid>
           <Grid item component={Card} xs>
             <StoreDetailCards stores={this.state.stores} style={{display: 'none'}}/>

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -78,6 +78,11 @@ h6 {
 
 /* StoresPage start */
 
+#stores-loading {
+  margin-top: 10px;
+  margin-bottom: 10px;
+}
+
 #stores-page-container {
   text-align: center;
   color: azure;


### PR DESCRIPTION
Apologies for the weird screenshot I had to take it really fast because the stores would load too fast

<img width="395" alt="Screen Shot 2020-07-21 at 9 11 15 PM" src="https://user-images.githubusercontent.com/51011816/88133648-6ef0da80-cb97-11ea-89ab-35046ac170f4.png">

I also modified the List Page so that the "Save List" button will not show up if you are not logged in

<img width="943" alt="Screen Shot 2020-07-21 at 9 23 26 PM" src="https://user-images.githubusercontent.com/51011816/88134075-909e9180-cb98-11ea-95e1-a5dfe19d17f9.png">

