### PR TITLE
Add option to select none for distance preference and modify wording.

### DIFF
--- a/capstone/backend/src/main/java/com/google/servlets/GetStoreRankingsServlet.java
+++ b/capstone/backend/src/main/java/com/google/servlets/GetStoreRankingsServlet.java
@@ -141,12 +141,12 @@ public class GetStoreRankingsServlet extends HttpServlet {
                 s2.getTotalUnavailableItemsFound() * UNAVALIABLE_ITEMS_WEIGHT
                     + s2.getLowestPotentialPrice() * PRICE_WEIGHT;
             if (!distances.isEmpty()) {
-              s1StoreScore +=
+              s1StoreScore -=
                   distances.get(s1.getStoreAddress())
                       / MILES_METERS_CONVERSION
                       / AVERAGE_MILES_PER_GALLON
                       * AVERAGE_GAS_PRICE;
-              s2StoreScore +=
+              s2StoreScore -=
                   distances.get(s2.getStoreAddress())
                       / MILES_METERS_CONVERSION
                       / AVERAGE_MILES_PER_GALLON

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -25,6 +25,8 @@ import { Alert } from '@material-ui/lab';
 
 import { Store } from './Store';
 
+const MAX_JAVA_INTEGER = 2147483647;
+
 /*
  * Displays a checkbox list containing the items returned from the Items API. 
  * The selected items are displayed below when the form is submitted. 
@@ -319,7 +321,7 @@ class ListPage extends Component {
               <FormControlLabel
                 control={<Radio name={"None"}/>}
                 label={"None"}
-                value={Number.MAX_SAFE_INTEGER}
+                value={MAX_JAVA_INTEGER}
                 key={"None"}
                 onChange={this.handleDistanceChange}
                />

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -293,8 +293,8 @@ class ListPage extends Component {
 
     const distances = [2, 4, 6, 8, 10, 12, 14].map((item) => (
       <FormControlLabel
-        control={<Radio name={item + " mile radius"}/>}
-        label={item + " mile radius"}
+        control={<Radio name={item + " miles from current location"}/>}
+        label={item + " miles from current location"}
         value={item}
         key={item}
         onChange={this.handleDistanceChange}
@@ -313,9 +313,16 @@ class ListPage extends Component {
         </ButtonGroup>
         <Grid container alignItems="stretch">
           <Grid id="distance-list-container" item component={Card} xs>
-            <p>I would like to choose from stores in a</p>
+            <p>Select a distance preference</p>
             <RadioGroup id="distance-list" value={this.state.distanceValue}>
-              {distances} 
+              {distances}
+              <FormControlLabel
+                control={<Radio name={"None"}/>}
+                label={"None"}
+                value={Number.MAX_SAFE_INTEGER}
+                key={"None"}
+                onChange={this.handleDistanceChange}
+               />
             </RadioGroup>
           </Grid>
           <Grid id="items-list-container" item component={Card} xs>


### PR DESCRIPTION
I added an option for selecting none as a distance preference. This will be useful for the demo if people are accessing the website from a location outside of the bay area. 

Also modified storeStore algorithm to subtract distance cost from store score. 