### PR TITLE
Move items into expandable item type categories and sort each category by price.

### DIFF
--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -16,7 +16,8 @@
 
 import React, { Component } from 'react';
 import { GoogleApiWrapper, Map } from 'google-maps-react';
-import { Card, Grid, List, ListItem, ListItemText, Typography } from '@material-ui/core';
+import { Accordion,  AccordionDetails, AccordionSummary, Card, Grid, List, ListItem, ListItemText, Typography } from '@material-ui/core';
+import ExpandMoreIcon from '@material-ui/icons/ExpandMore';
 
 import APIKey from './APIKey.js';
 import { StoresContext } from './StoresProvider.js';
@@ -38,19 +39,25 @@ class StoreDetailCards extends Component {
             </Map>
           </Grid>
           <Grid item component={Card} xs>
-            <Typography variant='subtitle1'>Has:</Typography>
-            <List>
+            <Typography variant='subtitle1'>This store has the following items:</Typography>
               {Object.keys(store.items).map((itemType, i) => (
-                <div>{Object.keys(store.items[itemType]).map((index, i) => (
-                  <ListItem key = {i}>
-                  <ListItemText>
-                    {store.items[itemType][index].itemName} (${(store.items[itemType][index].itemPrice-.005).toFixed(2)})
-                  </ListItemText>
-                </ListItem>
-                ))}
-                </div>
+                <Accordion>
+                  <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                    <Typography variant='subtitle1'>{itemType}</Typography>
+                  </AccordionSummary>
+                  <AccordionDetails>
+                    <List>
+                    {Object.keys(store.items[itemType].sort((a, b) => a.itemPrice - b.itemPrice)).map((index, i) => (
+                      <ListItem key = {i}>
+                        <ListItemText>
+                          {store.items[itemType][index].itemName} (${(store.items[itemType][index].itemPrice-.005).toFixed(2)})
+                        </ListItemText>
+                      </ListItem>
+                    ))}
+                    </List>
+                  </AccordionDetails>
+                </Accordion>
               ))}
-            </List>
           </Grid>
         </Grid>
       </div>


### PR DESCRIPTION
Moved items into categories grouped by itemType. Items are sorted by price in each itemType category. This makes it easier to navigate and find specific items as opposed to having to search through a long unsorted list of all the items the store has.

The following screenshot shows the changes:
![image](https://user-images.githubusercontent.com/43008373/88205855-376b4800-cc02-11ea-9544-def2794ef1a1.png)
