### PR TITLE
Add a dialog for the success or error of saving the user's list.

### DIFF
--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -51,6 +51,10 @@ class ListPage extends Component {
       listSaveDialog: {
         display: false,
       },
+      listSaveStatus: {
+        display: false,
+      },
+      listStatusMessage: null,
       redirect : null,
     }
   }
@@ -171,6 +175,14 @@ class ListPage extends Component {
     })
   }
 
+  handleListStatusDialogClose = () => {
+    this.setState({
+      listSaveStatus: {
+        display: false,
+      },
+    })
+  }
+
   /* 
    * Obtains the selected items from the checkbox list and makes a POST request to 
    * /api/v1/create-or-update-user-list-servlet to save the specified list.
@@ -194,12 +206,20 @@ class ListPage extends Component {
       },
     ).then((res) => {
       this.setState({
+        listStatusMessage: "Your list has been saved!",
+        listSaveStatus: {
+          display: true,
+        },
         errorMessage: null,
         successMessage: "Your list has been saved!",
         listId: res.data.userList.listId,
       });
     }).catch((error) => {
       this.setState({
+        listStatusMessage: "There was an error saving your list.",
+        listSaveStatus: {
+          display: true,
+        },
         errorMessage: "There was an error saving your list.",
       })
     });
@@ -356,6 +376,23 @@ class ListPage extends Component {
             </Button>
             <Button disabled={this.state.listSaveDialog.saveButtonDisabled} onClick={this.handleDialogSubmit} color="primary">
               Save
+            </Button>
+          </DialogActions>
+        </Dialog>
+        <Dialog
+        open={this.state.listSaveStatus.display}
+        onClose={this.handleListStatusDialogClose}
+        aria-labelledby="form-dialog-title"
+        aria-describedby="form-dialog-description">
+          <DialogTitle id="list-save-dialog-title">{"List Status"}</DialogTitle>
+          <DialogContent>
+            <DialogContentText id="list-save-dialog-text">
+              {this.state.listStatusMessage}
+            </DialogContentText>
+          </DialogContent>
+          <DialogActions>
+            <Button onClick={this.handleListStatusDialogClose} color="primary">
+              OK
             </Button>
           </DialogActions>
         </Dialog>

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -54,7 +54,6 @@ class ListPage extends Component {
       listSaveStatus: {
         display: false,
       },
-      listStatusMessage: null,
       redirect : null,
     }
   }
@@ -206,7 +205,6 @@ class ListPage extends Component {
       },
     ).then((res) => {
       this.setState({
-        listStatusMessage: "Your list has been saved!",
         listSaveStatus: {
           display: true,
         },
@@ -216,7 +214,6 @@ class ListPage extends Component {
       });
     }).catch((error) => {
       this.setState({
-        listStatusMessage: "There was an error saving your list.",
         listSaveStatus: {
           display: true,
         },
@@ -323,6 +320,18 @@ class ListPage extends Component {
 
     const saveButton = (this.state.userId === -1) ? <div></div> : <Button onClick={this.onSave} color="secondary" variant="contained">Save List</Button>;
 
+    let listSaveMessage;
+    // If the list was successfully saved.
+    if (this.state.successMessage != null) {
+      listSaveMessage = (<DialogContentText id="list-save-dialog-text">
+        {this.state.successMessage}
+        </DialogContentText>);
+    } else if (this.state.errorMessage != null) {
+      listSaveMessage = (<DialogContentText id="list-save-dialog-text">
+        {this.state.errorMessage}
+        </DialogContentText>);
+    }
+
     return (
       <div id="list-page-container">
         {this.state.errorMessage ? <Alert severity="error">{this.state.errorMessage}</Alert> : null}
@@ -386,9 +395,7 @@ class ListPage extends Component {
         aria-describedby="form-dialog-description">
           <DialogTitle id="list-save-dialog-title">{"List Status"}</DialogTitle>
           <DialogContent>
-            <DialogContentText id="list-save-dialog-text">
-              {this.state.listStatusMessage}
-            </DialogContentText>
+            {listSaveMessage}
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleListStatusDialogClose} color="primary">

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -59,6 +59,7 @@ class ListPage extends Component {
       listSaveStatus: {
         display: false,
       },
+      listSaveStatusMessage: null,
       redirect : null,
       zipCode : null,
       zipCodeError: true,
@@ -243,8 +244,7 @@ class ListPage extends Component {
         listSaveStatus: {
           display: true,
         },
-        errorMessage: null,
-        successMessage: "Your list has been saved!",
+        listSaveStatusMessage: "Your list has been saved!",
         listId: res.data.userList.listId,
       });
     }).catch((error) => {
@@ -252,7 +252,7 @@ class ListPage extends Component {
         listSaveStatus: {
           display: true,
         },
-        errorMessage: "There was an error saving your list.",
+        listSaveStatusMessage: "There was an error saving your list.",
       })
     });
   }
@@ -370,18 +370,6 @@ class ListPage extends Component {
 
     const saveButton = (this.state.userId === -1) ? null : <Button onClick={this.onSave} color="secondary" variant="contained">Save List</Button>;
 
-    let listSaveMessage;
-    // If the list was successfully saved.
-    if (this.state.successMessage != null) {
-      listSaveMessage = (<DialogContentText id="list-save-dialog-text">
-        {this.state.successMessage}
-        </DialogContentText>);
-    } else if (this.state.errorMessage != null) {
-      listSaveMessage = (<DialogContentText id="list-save-dialog-text">
-        {this.state.errorMessage}
-        </DialogContentText>);
-    }
-
     return (
       <div id="list-page-container">
         {this.state.errorMessage ? <Alert severity="error">{this.state.errorMessage}</Alert> : null}
@@ -453,7 +441,9 @@ class ListPage extends Component {
         aria-describedby="form-dialog-description">
           <DialogTitle id="list-save-dialog-title">{"List Status"}</DialogTitle>
           <DialogContent>
-            {listSaveMessage}
+          <DialogContentText id="list-save-dialog-text">
+            {this.state.listSaveStatusMessage}
+          </DialogContentText>
           </DialogContent>
           <DialogActions>
             <Button onClick={this.handleListStatusDialogClose} color="primary">


### PR DESCRIPTION
I left the error/success messages that appear at the top of the page intact for now. Should I remove them now that they're superfluous? For example: 
![with banner](https://user-images.githubusercontent.com/12992501/88247591-226ad500-cc53-11ea-9810-e64a7969ad8e.png)

Here is what the new dialog boxes look like:
![error](https://user-images.githubusercontent.com/12992501/88247399-6b6e5980-cc52-11ea-9c40-973eddc08307.png)
![success](https://user-images.githubusercontent.com/12992501/88247401-6c06f000-cc52-11ea-9899-befdda367479.png)
