### PR TITLE
Change list selection buttons to dropdown to allow support for a larger number of saved lists.

### DIFF
--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -17,7 +17,7 @@
 import React, { Component } from 'react';
 import {Redirect} from 'react-router-dom';
 import axios from 'axios';
-import { Card, FormControlLabel, Grid, List, MenuItem, Radio, Select, TextField } from '@material-ui/core';
+import { Card, Grid, InputLabel, MenuItem, Select } from '@material-ui/core';
 import { Add, Create } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
 
@@ -168,6 +168,7 @@ class ListPage extends Component {
         <h1>Item Selection</h1>
         {this.state.userId === -1 ? null : 
           <div id="list-selection-buttons-container">
+            <InputLabel>Select from saved lists</InputLabel>
             <Select variant="standard" value={this.state.listIndex} container id="user-lists" onClick={this.selectList}>
               <MenuItem id="list-button" value={-1} key={-1}>
                 <Add fontSize="small"/><span> </span>New list

--- a/capstone/client/src/components/ListPage.js
+++ b/capstone/client/src/components/ListPage.js
@@ -17,7 +17,8 @@
 import React, { Component } from 'react';
 import {Redirect} from 'react-router-dom';
 import axios from 'axios';
-import { Button, ButtonGroup, Card, FormControlLabel, Grid, List, Radio, TextField } from '@material-ui/core';
+import { Card, FormControlLabel, Grid, List, MenuItem, Radio, Select, TextField } from '@material-ui/core';
+import { Add, Create } from '@material-ui/icons';
 import { Alert } from '@material-ui/lab';
 
 import { Store } from './Store';
@@ -45,8 +46,9 @@ class ListPage extends Component {
       items: [],
       selectedItems: new Set(),
       listId: -1,
+      listIndex: -1,
       listName: null,
-      userId: -1,
+      userId: this.props.store.get('userId'),
       location: { // San Jose by default
         latitude: 37.338207,
         longitude: -121.886330,
@@ -66,18 +68,6 @@ class ListPage extends Component {
       });
     });
   
-    navigator.geolocation.getCurrentPosition((position) => {
-      this.setState({
-        location: {
-          latitude: position.coords.latitude,
-          longitude: position.coords.longitude,
-        },
-      });
-    }, () => {
-      this.setState({
-        zipCodeRequired: true,
-      });
-    });
     if(this.state.userId !== -1) {
       axios.get('/api/v1/get-user-lists', { params : { userId : this.state.userId }})
         .then(res => {
@@ -129,12 +119,21 @@ class ListPage extends Component {
   }
 
   selectList = (event) => {
-    var index = event.target.name;
-    if(event.target.className === "MuiButton-label"){
-      index = event.target.parentElement.name;
+    const index = event.target.value;
+    if (index === undefined) {
+      return;
+    }
+    if (index === -1) {
+      this.setState({
+        listId: -1,
+        listIndex: -1,
+        selectedItems: new Set(),
+      });
+      return;
     }
     this.setState({
       listId : this.state.userLists[index].listId,
+      listIndex: index,
       selectedItems: new Set(this.state.userLists[index].itemTypes),
     });
   }
@@ -157,7 +156,9 @@ class ListPage extends Component {
     }
 
     const userListButtons = this.state.userLists.map((userList, index) => (
-      <Button id="list-button" name={index}>{userList.displayName}</Button>
+      <MenuItem id="list-button" value={index} key={index}> 
+        <Create /><span> </span>{userList.displayName}
+      </MenuItem>
     ));
 
     return (
@@ -165,9 +166,16 @@ class ListPage extends Component {
         {this.state.errorMessage ? <Alert severity="error">{this.state.errorMessage}</Alert> : null}
         {this.state.successMessage ? <Alert severity="success">{this.state.successMessage}</Alert> : null}
         <h1>Item Selection</h1>
-        <ButtonGroup container id="user-lists" onClick={this.selectList}>
-          {userListButtons}
-        </ButtonGroup>
+        {this.state.userId === -1 ? null : 
+          <div id="list-selection-buttons-container">
+            <Select variant="standard" value={this.state.listIndex} container id="user-lists" onClick={this.selectList}>
+              <MenuItem id="list-button" value={-1} key={-1}>
+                <Add fontSize="small"/><span> </span>New list
+              </MenuItem>
+              {userListButtons}
+            </Select>
+          </div>
+        }
         <Grid container alignItems="stretch">
           <Grid id="items-list-container" item component={Card} xs>
             {<ItemsList items={this.state.items} selectedItems={this.state.selectedItems} userId={this.state.userId} listId={this.state.listId} onSubmit={this.onSubmit}/>}

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -75,8 +75,7 @@ h6 {
   background-size: cover;
   color: azure;
   min-height: 100%;
-  position: fixed;
-  text-align: center;
+  text-align: right;
 }
 
 #items-container {
@@ -155,10 +154,15 @@ h6 {
   width: 140px;
 }
 
-#list-button {
+#list-selection-buttons-container {
+  margin: 0 15% 0 0;
+}
+
+#user-lists {
   background-color: #a782da;
-  border-radius: 24px;
-  margin: 0 10px 10px 10px;
+  color: white;
+  text-align: center;
+  width: 130px;
 }
 
 /* ListPage end */

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -162,7 +162,7 @@ h6 {
   background-color: #a782da;
   color: white;
   text-align: center;
-  width: 130px;
+  width: 140px;
 }
 
 /* ListPage end */


### PR DESCRIPTION
Changes:
- Fixed the scrolling issues on the item selection page. 

- Created a "new list" option that will deselect all the selected items and allow the user to create a new list instead of existing one of the existing ones. The selected list appears in the dropdown making it clear which list is currently being viewed. 

- Obtained the userId properly so the hidden buttons and saved lists appear when an user click go back from the stores page

The following is are screenshots showing the changes:
![image](https://user-images.githubusercontent.com/43008373/88603389-a1805480-d029-11ea-97ce-87e8aaf61100.png)
![image](https://user-images.githubusercontent.com/43008373/88603406-ae9d4380-d029-11ea-88f5-41521b7de01f.png)

