### PR TITLE
Made Stores Page Scrollable

### DIFF
--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -252,10 +252,12 @@ class StorePage extends Component {
         <Grid container alignItems="stretch">
           <Grid item component={Card} xs={4}>
             <FilterStores originalStores={this.state.originalStores} items={this.state.items} onFilterChange={this.handleFilterChange}/>
-            {overviewCards}
+            <div id="overview-cards">{overviewCards}</div>
           </Grid>
           <Grid item component={Card} xs>
+            <div id="details-cards">
             <StoreDetailCards stores={this.state.stores} style={{display: 'none'}}/>
+            </div>
           </Grid>
         </Grid> 
         </StoresProvider>

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -369,6 +369,11 @@ h6 {
   padding: 20px;
 }
 
+#overview-cards {
+  height: 400px;
+  overflow-y: scroll;
+}
+
 /* StoreOverviewCards end */
 
 /* StoreDetailCards start */
@@ -380,6 +385,11 @@ h6 {
 
 #store-details-container {
   margin-top : 20px;
+}
+
+#details-cards {
+  height: 600px;
+  overflow-y: scroll;
 }
 
 /* StoreDetailCards end */


### PR DESCRIPTION
Separated the grids on the stores page into divs that have a maximum height and are scrollable if they overflow (which they almost always do)

<img width="1752" alt="Screen Shot 2020-07-29 at 2 44 23 PM" src="https://user-images.githubusercontent.com/51011816/88856971-4d50ae00-d1aa-11ea-86aa-326a153c2cad.png">
