### PR TITLE
Modify styling and the get directions button.

### DIFF
--- a/capstone/client/src/components/StoreDetailCards.js
+++ b/capstone/client/src/components/StoreDetailCards.js
@@ -76,7 +76,7 @@ class StoreDetailCards extends Component {
         <Typography variant='h6'>Address: {store.storeAddress}</Typography>
         <Grid container alignItems="stretch">
           <Grid item component={Card} xs>
-            <StoreMaps store={store}/>
+            <StoreMaps store={store} userLat={this.props.userLat} userLong={this.props.userLong} />
           </Grid>
           <Grid item component={Card} xs>
             <Typography variant='subtitle1'>This store has the following items:</Typography>

--- a/capstone/client/src/components/StoreMaps.js
+++ b/capstone/client/src/components/StoreMaps.js
@@ -72,12 +72,11 @@ class StoreMaps extends Component {
   }
 
   getDirectionsUrl(address) {
-    let url;
+    let url = 'https://www.google.com/maps/dir/?api=1';
     if (this.state.userAddress) {
-      url = 'https://www.google.com/maps/dir/?api=1&origin=' + encodeURIComponent(this.state.userAddress) + '&destination=' + encodeURIComponent(address);
-    } else {
-      url = 'https://www.google.com/maps/dir/?api=1&destination=' + encodeURIComponent(address);
-    }
+      url = url + '&origin=' + encodeURIComponent(this.state.userAddress);
+    } 
+    url = url + '&destination=' + encodeURIComponent(address);
 
     this.setState({
       url,

--- a/capstone/client/src/components/StoreMaps.js
+++ b/capstone/client/src/components/StoreMaps.js
@@ -29,6 +29,7 @@ class StoreMaps extends Component {
     this.state = {
       latitude: 0,
       longitude: 0,
+      userAddress: null,
       url: null,
     }
   } 
@@ -51,6 +52,16 @@ class StoreMaps extends Component {
     Geocode.setApiKey(APIKey.APIKey());
     this.getLatLangFromAddress(this.props.store.storeAddress);
     this.getDirectionsUrl(this.props.store.storeAddress);
+
+    Geocode.fromLatLng(this.props.userLat, this.props.userLong).then(
+      response => {
+        const address = response.results[0].formatted_address;
+        this.setState({
+          userAddress: address,
+        });
+        this.getDirectionsUrl(this.props.store.storeAddress);
+      }
+    );
   }
 
   componentDidUpdate = (prevProps) => {
@@ -61,7 +72,13 @@ class StoreMaps extends Component {
   }
 
   getDirectionsUrl(address) {
-    const url = 'https://www.google.com/maps/dir/?api=1&destination=' + encodeURIComponent(address);
+    let url;
+    if (this.state.userAddress) {
+      url = 'https://www.google.com/maps/dir/?api=1&origin=' + encodeURIComponent(this.state.userAddress) + '&destination=' + encodeURIComponent(address);
+    } else {
+      url = 'https://www.google.com/maps/dir/?api=1&destination=' + encodeURIComponent(address);
+    }
+
     this.setState({
       url,
     });
@@ -72,19 +89,16 @@ class StoreMaps extends Component {
   }
 
   render() {
-    const style = {
-      width: '75%'
-    }
-
     const containerStyle = {
       position: 'relative',
       width: '500px', 
-      height: '400px'
+      height: '400px',
+      marginBottom: '20px'
     }
 
     return (
       <div>
-        <Map id="google-map" google={this.props.google} containerStyle={containerStyle} style={style} zoom={14}
+        <Map id="google-map" google={this.props.google} containerStyle={containerStyle} zoom={14}
           center={{lat: this.state.latitude, lng: this.state.longitude}}>
           <Marker position={{lat: this.state.latitude, lng: this.state.longitude}}/>
         </Map>

--- a/capstone/client/src/components/StoresPage.js
+++ b/capstone/client/src/components/StoresPage.js
@@ -259,7 +259,7 @@ class StorePage extends Component {
           </Grid>
           <Grid item component={Card} xs>
             <div id="details-cards">
-            <StoreDetailCards stores={this.state.stores} style={{display: 'none'}}/>
+            <StoreDetailCards stores={this.state.stores} userLat={this.state.latitude} userLong={this.state.longitude} style={{display: 'none'}}/>
             </div>
           </Grid>
         </Grid> 

--- a/capstone/client/src/components/styles.css
+++ b/capstone/client/src/components/styles.css
@@ -350,6 +350,7 @@ h6 {
   color : #111;
   font-family: 'Open Sans',serif;
   text-transform: none;
+  margin-bottom: 20px;
 }
 
 #stores-loading {


### PR DESCRIPTION
Now, when you get directions, Google Maps shows the path from the inputted address (on the Welcome page) to the store, as opposed to the user's tracked location to the store.
Minor adjustments to style:
![image](https://user-images.githubusercontent.com/12992501/89481219-25ce8800-d74c-11ea-89e4-964a7b0731db.png)
